### PR TITLE
[preproc] parse enum only in 2nd pass

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -367,7 +367,7 @@ $(C_BUILDDIR)/%.o: $(C_SUBDIR)/%.s
 else
 define SRC_ASM_DATA_DEP
 $1: $2 $$(shell $(SCANINC) -I include -I "" $2)
-	$$(PREPROC) $$< charmap.txt | $$(CPP) -I include - | $$(PREPROC) $$< charmap.txt -i | $$(AS) $$(ASFLAGS) -o $$@
+	$$(PREPROC) $$< charmap.txt | $$(CPP) -I include - | $$(PREPROC) $$< charmap.txt -i -e | $$(AS) $$(ASFLAGS) -o $$@
 endef
 $(foreach src, $(C_ASM_SRCS), $(eval $(call SRC_ASM_DATA_DEP,$(patsubst $(C_SUBDIR)/%.s,$(C_BUILDDIR)/%.o, $(src)),$(src))))
 endif
@@ -385,7 +385,7 @@ endif
 
 ifeq ($(NODEP),1)
 $(DATA_ASM_BUILDDIR)/%.o: $(DATA_ASM_SUBDIR)/%.s
-	$(PREPROC) $< charmap.txt | $(CPP) -I include - | $(PREPROC) $$< charmap.txt -i | $(AS) $(ASFLAGS) -o $@
+	$(PREPROC) $< charmap.txt | $(CPP) -I include - | $(PREPROC) $$< charmap.txt -i -e | $(AS) $(ASFLAGS) -o $@
 else
 $(foreach src, $(REGULAR_DATA_ASM_SRCS), $(eval $(call SRC_ASM_DATA_DEP,$(patsubst $(DATA_ASM_SUBDIR)/%.s,$(DATA_ASM_BUILDDIR)/%.o, $(src)),$(src))))
 endif

--- a/tools/preproc/asm_file.h
+++ b/tools/preproc/asm_file.h
@@ -38,7 +38,7 @@ enum class Directive
 class AsmFile
 {
 public:
-    AsmFile(std::string filename, bool isStdin);
+    AsmFile(std::string filename, bool isStdin, bool doEnum);
     AsmFile(AsmFile&& other);
     AsmFile(const AsmFile&) = delete;
     ~AsmFile();
@@ -54,6 +54,7 @@ public:
 
 private:
     char* m_buffer;
+    bool m_doEnum;
     long m_pos;
     long m_size;
     long m_lineNum;

--- a/tools/preproc/io.cpp
+++ b/tools/preproc/io.cpp
@@ -1,6 +1,7 @@
 #include "preproc.h"
 #include "io.h"
 #include <string>
+#include <cerrno>
 #include <cstring>
 
 char *ReadFileToBuffer(const char *filename, bool isStdin, long *size)

--- a/tools/preproc/preproc.cpp
+++ b/tools/preproc/preproc.cpp
@@ -20,6 +20,7 @@
 
 #include <string>
 #include <stack>
+#include <unistd.h>
 #include "preproc.h"
 #include "asm_file.h"
 #include "c_file.h"
@@ -43,11 +44,11 @@ void PrintAsmBytes(unsigned char *s, int length)
     }
 }
 
-void PreprocAsmFile(std::string filename, bool isStdin)
+void PreprocAsmFile(std::string filename, bool isStdin, bool doEnum)
 {
     std::stack<AsmFile> stack;
 
-    stack.push(AsmFile(filename, isStdin));
+    stack.push(AsmFile(filename, isStdin, doEnum));
     std::printf("# 1 \"%s\"\n", filename.c_str());
 
     for (;;)
@@ -67,7 +68,7 @@ void PreprocAsmFile(std::string filename, bool isStdin)
         switch (directive)
         {
         case Directive::Include:
-            stack.push(AsmFile(stack.top().ReadPath(), false));
+            stack.push(AsmFile(stack.top().ReadPath(), false, doEnum));
             stack.top().OutputLocation();
             break;
         case Directive::String:
@@ -116,9 +117,9 @@ void PreprocCFile(const char * filename, bool isStdin)
     cFile.Preproc();
 }
 
-char* GetFileExtension(char* filename)
+const char* GetFileExtension(const char* filename)
 {
-    char* extension = filename;
+    const char* extension = filename;
 
     while (*extension != 0)
         extension++;
@@ -137,45 +138,75 @@ char* GetFileExtension(char* filename)
     return extension;
 }
 
+static void usage_and_exit(const char *argv0)
+{
+    std::fprintf(stderr, "Usage: %s SRC_FILE CHARMAP_FILE [-i] [-e]\nwhere -i denotes if input is from stdin\n      -e enables enum handling\n", argv0);
+    std::exit(EXIT_FAILURE);
+}
+
 int main(int argc, char **argv)
 {
-    if (argc < 3 || argc > 4)
+    int opt;
+    const char *source = NULL;
+    const char *charmap = NULL;
+    bool isStdin = false;
+    bool doEnum = false;
+
+    /* preproc SRC_FILE CHARMAP_FILE [-i] [-e] */
+    while ((opt = getopt(argc, argv, "-ie")) != -1)
     {
-        std::fprintf(stderr, "Usage: %s SRC_FILE CHARMAP_FILE [-i]\nwhere -i denotes if input is from stdin\n", argv[0]);
-        return 1;
+        switch (opt)
+        {
+        case 1: // positional.
+            switch (optind)
+            {
+            case 2:
+                source = optarg;
+                break;
+            case 3:
+                charmap = optarg;
+                break;
+            default:
+                usage_and_exit(argv[0]);
+                break;
+            }
+            break;
+        case 'i':
+            isStdin = true;
+            break;
+        case 'e':
+            doEnum = true;
+            break;
+        default:
+            usage_and_exit(argv[0]);
+            break;
+        }
     }
 
-    g_charmap = new Charmap(argv[2]);
+    if (optind != argc || !source || !charmap)
+        usage_and_exit(argv[0]);
 
-    char* extension = GetFileExtension(argv[1]);
+    g_charmap = new Charmap(charmap);
+
+    const char* extension = GetFileExtension(source);
 
     if (!extension)
         FATAL_ERROR("\"%s\" has no file extension.\n", argv[1]);
 
-    if ((extension[0] == 's') && extension[1] == 0) {
-        if (argc == 4) {
-            if (argv[3][0] == '-' && argv[3][1] == 'i' && argv[3][2] == '\0') {
-                PreprocAsmFile(argv[1], true);
-            } else {
-                FATAL_ERROR("unknown argument flag \"%s\".\n", argv[3]);
-            }
-        } else {
-            PreprocAsmFile(argv[1], false);
-        }
-        
+    if ((extension[0] == 's') && extension[1] == 0)
+    {
+        PreprocAsmFile(source, isStdin, doEnum);
     }
-    else if ((extension[0] == 'c' || extension[0] == 'i') && extension[1] == 0) {
-        if (argc == 4) {
-            if (argv[3][0] == '-' && argv[3][1] == 'i' && argv[3][2] == '\0') {
-                PreprocCFile(argv[1], true);
-            } else {
-                FATAL_ERROR("unknown argument flag \"%s\".\n", argv[3]);
-            }
-        } else {
-            PreprocCFile(argv[1], false);
-        }
-    } else
+    else if ((extension[0] == 'c' || extension[0] == 'i') && extension[1] == 0)
+    {
+        if (doEnum)
+            FATAL_ERROR("-e is invalid for C sources\n");
+        PreprocCFile(source, isStdin);
+    }
+    else
+    {
         FATAL_ERROR("\"%s\" has an unknown file extension of \"%s\".\n", argv[1], extension);
+    }
 
     return 0;
 }


### PR DESCRIPTION
- Parse `enum` only in 2nd pass (`-e`).
- Add `symbolCount++` and rearrange `if`s so that trailing commas are supported.